### PR TITLE
Update canister IDs

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,11 +1,11 @@
 {
   "artist": {
-    "ic": "i3ad2-7aaaa-aaaab-qabkq-cai"
+    "ic": "36szl-siaaa-aaaaa-qaaxa-cai"
   },
   "curator": {
-    "ic": "227wz-liaaa-aaaaa-qaara-cai"
+    "ic": "htg4w-ziaaa-aaaab-aabaa-cai"
   },
   "frontend": {
-    "ic": "isdig-jiaaa-aaaab-qabla-cai"
+    "ic": "3zt77-7qaaa-aaaaa-qaaxq-cai"
   }
 }


### PR DESCRIPTION
Since the app got deployed on testnet with the second try and without the need to renew the latest canister IDs (see https://github.com/OmeGak/resonate/issues/40#issuecomment-761876252), it might be worth merging the latest canister IDs to `devel`.