### PR TITLE
Retrieve pending submission ids for curator

### DIFF
--- a/src/backend/curator/main.mo
+++ b/src/backend/curator/main.mo
@@ -69,4 +69,14 @@ actor Curator {
       case (null) { () };
     }
   };
+
+  public func getPendingSubmissions(curatorId: ProfileId): async ?[SubmissionId] {
+    let curator = curators.find(curatorId);
+    switch (curator) {
+      case (?curator) { return ?curator.pending };
+      // TODO: raise proper error
+      case (null) { return null };
+    }
+  };
+
 };


### PR DESCRIPTION
Closes #50

It wasn't possible to return actual `Submission` objects because there's a circular dependency that I was unable to solve. We'll have to deal with this for the moment.