### PR TITLE
Fix HTTP code used for redirect

### DIFF
--- a/bin/redirect-server.js
+++ b/bin/redirect-server.js
@@ -8,8 +8,8 @@ const FRONTEND_CANISTER_ID = 'r7inp-6aaaa-aaaaa-aaabq-cai';
 // removes the `canisterId=` parameter from the callback URL.
 const server = http.createServer((request, response) => {
   // Redirect to the frontend canister in the local DFINITY replica
-  response.writeHead(301, {
     'Location': `http://${dfxConfig.networks.local.bind}?canisterId=${FRONTEND_CANISTER_ID}`,
+  response.writeHead(307, {
   });
   response.end();
 })


### PR DESCRIPTION
The currently used redirect code (`301 Move Permanently`) is not the right code to use in our use-case, because now Chrome/Brave has cached the redirect rule and I need to clear my browser cache to fix it. I should have used the `307 Temporary Redirect`.

https://en.wikipedia.org/wiki/List_of_HTTP_status_codes